### PR TITLE
Hard Write Disabled AA Gun

### DIFF
--- a/map/games/ww2_risk_of_defeat.xml
+++ b/map/games/ww2_risk_of_defeat.xml
@@ -1375,6 +1375,7 @@
 		<unit name="carrier"/>
 		<unit name="battleship"/>
 		<unit name="aaGun"/>
+		<unit name="aaGun_disabled"/>
 		<unit name="airfield"/>
 		<unit name="harbour"/>
 		<unit name="factory_minor"/>
@@ -1882,7 +1883,7 @@
       <option name="bombingBonus" value="1"/>
 	  <option name="airDefense" value="1"/>
       <option name="airAttack" value="0"/>
-	  <option name="bombingTargets" value="factory_minor:factory_upgrade:factory_major:airfield:harbour:aaGun"/>
+	  <option name="bombingTargets" value="factory_minor:factory_upgrade:factory_major:airfield:harbour:aaGun:aaGun_disabled"/>
 	  <option name="requiresUnits" value="airfield:factory_minor"/>
 	  <option name="requiresUnits" value="airfield:factory_upgrade"/>
 	  <option name="requiresUnits" value="airfield:factory_major"/>
@@ -1904,7 +1905,7 @@
       <option name="bombingMaxDieSides" value="2"/>
       <option name="bombingBonus" value="0"/>
 	  <option name="requiresUnits" value="airfield"/>
-      <option name="bombingTargets" value="airfield:harbour:aaGun"/>
+      <option name="bombingTargets" value="airfield:harbour:aaGun:aaGun_disabled"/>
     </attachment>
 	
     <!-- Transport -->
@@ -2104,10 +2105,23 @@
       <option name="maxAAattacks" value="1"/>
 	  <option name="canBeDamaged" value="true"/>
 	  <option name="maxDamage" value="3"/>
-	  <option name="maxOperationalDamage" value="0"/>
+<!--	  <option name="maxOperationalDamage" value="0"/>-->
 	  <option name="canDieFromReachingMaxDamage" value="true"/>
 	  <option name="whenCapturedSustainsDamage" value="1"/>
-	  <option name="whenCombatDamaged" value="maxAAattacks:0" count="1:2"/>
+	  <option name="whenHitPointsDamagedChangedInto" value="aaGun_disabled" count="1:2"/>
+    </attachment>
+	
+	<attachment name="unitAttachment" attachTo="aaGun_disabled" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="isAA" value="false"/>
+      <option name="canNotMoveDuringCombatMove" value="true"/>
+      <option name="movement" value="1"/>
+      <option name="transportCost" value="5"/>
+	  <option name="canBeDamaged" value="true"/>
+	  <option name="maxDamage" value="3"/>
+<!--	  <option name="maxOperationalDamage" value="0"/>-->
+	  <option name="canDieFromReachingMaxDamage" value="true"/>
+	  <option name="whenCapturedSustainsDamage" value="1"/>
+	  <option name="whenHitPointsRepairedChangedInto" value="aaGun" count="0"/>
     </attachment>
 	
 	<!--Territory Values-->


### PR DESCRIPTION
Trying a different AA disabled approach because "whenCombatDamaged" only works for carriers right now. Trying to make aaGun become a manually defined "disabled" unit when at 1 or 2 damage, and likewise switch back when the disabled unit is repaired, but both can die at 3 damage